### PR TITLE
Add slack error notification

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,8 @@ gem 'font-awesome-rails'
 gem 'devise'
 gem 'newrelic_rpm'
 gem 'clipboard-rails'
+gem 'exception_notification'
+gem 'slack-notifier'
 
 source 'https://rails-assets.org' do
   gem 'rails-assets-tether', '>= 1.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -94,6 +94,9 @@ GEM
       dotenv (= 2.1.1)
       railties (>= 4.0, < 5.1)
     erubis (2.7.0)
+    exception_notification (4.2.1)
+      actionmailer (>= 4.0, < 6)
+      activesupport (>= 4.0, < 6)
     execjs (2.7.0)
     factory_girl (4.7.0)
       activesupport (>= 3.0.0)
@@ -217,6 +220,7 @@ GEM
       tilt (>= 1.1, < 3)
     shoulda-matchers (3.1.1)
       activesupport (>= 4.0.0)
+    slack-notifier (2.1.0)
     slop (3.6.0)
     spring (2.0.0)
       activesupport (>= 4.2)
@@ -270,6 +274,7 @@ DEPENDENCIES
   database_cleaner
   devise
   dotenv-rails
+  exception_notification
   factory_girl_rails
   font-awesome-rails
   hover-rails
@@ -288,6 +293,7 @@ DEPENDENCIES
   rspec-rails (~> 3.5)
   sass-rails (~> 5.0)
   shoulda-matchers (~> 3.1)
+  slack-notifier
   spring
   spring-watcher-listen (~> 2.0.0)
   therubyracer

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -75,7 +75,7 @@ Rails.application.configure do
   # require 'syslog/logger'
   # config.logger = ActiveSupport::TaggedLogging.new(Syslog::Logger.new 'app-name')
 
-  if ENV["RAILS_LOG_TO_STDOUT"].present?
+  if ENV['RAILS_LOG_TO_STDOUT'].present?
     logger           = ActiveSupport::Logger.new(STDOUT)
     logger.formatter = config.log_formatter
     config.logger = ActiveSupport::TaggedLogging.new(logger)
@@ -98,4 +98,14 @@ Rails.application.configure do
   }
 
   config.action_mailer.default_url_options = { host: 'charactersheets.org' }
+
+  # Slack webhook integration
+  Rails.application.config.middleware.use ExceptionNotification::Rack,
+  :slack => {
+    :webhook_url => ENV['CS_SLACK_WEBHOOK'],
+    :channel => '#exceptions',
+    :additional_parameters => {
+      :mrkdwn => true
+    }
+  }
 end


### PR DESCRIPTION
When error occurs, exception_notification sends a nice message to charactersheets Slack exceptions channel. Synchronous for now.